### PR TITLE
Several fixes from Claude

### DIFF
--- a/Application/Application.cpp
+++ b/Application/Application.cpp
@@ -156,6 +156,13 @@ Result Application::TimerExpired(uint32_t missed_cnt)
   // handling of Metric/Imperial or Mill/Lathe change
   if(grbl_comm.IsSettingsChanged())
   {
+    // Hide modal boxes if any is on the screen: all screens are about to be
+    // re-initialized and screen 0 shown, so a callback from a stale box
+    // would be routed to the wrong screen and misinterpreted there(the box
+    // objects are shared between screens).
+    change_value_box.Hide();
+    msg_box.Hide();
+
     // Check controller settings
     if(!grbl_comm.IsWorkOffsetReportEnabled())
     {

--- a/Application/DirectControlScr.cpp
+++ b/Application/DirectControlScr.cpp
@@ -143,6 +143,18 @@ Result DirectControlScr::Show()
     dw[i].SetSelected(false);
   }
 
+  // Clear jog values and directions: encoder clicks buffered between the last
+  // timer tick and Hide() are never consumed while the screen is hidden and
+  // would cause unexpected movement on the first tick after the screen is
+  // shown again.
+  for(uint32_t i = 0u; i < GrblComm::AXIS_CNT; i++)
+  {
+    axis_jog_val[i] = 0;
+    axis_jog_dir[i] = 0;
+  }
+  // Clear spindle speed change value for the same reason
+  jog_val = 0;
+
   // In Lathe mode show Radius/Diameter string on top of X window and button to change it
   if(grbl_comm.GetModeOfOperation() == GrblComm::MODE_OF_OPERATION_LATHE)
   {
@@ -547,9 +559,16 @@ Result DirectControlScr::ProcessEncoderCallback(DirectControlScr* obj_ptr, void*
     {
       ths.axis_jog_val[ths.axis] += enc_val;
     }
+    else if(ths.spindle_dw.IsSelected())
+    {
+      // Spindle speed can be changed by the encoder only if spindle data
+      // window is explicitly selected, otherwise wheel rotation right after
+      // the screen is shown(no axis selected yet) would change spindle speed.
+      ths.jog_val += enc_val;
+    }
     else
     {
-      ths.jog_val += enc_val;
+      ; // Neither axis nor spindle selected - ignore encoder input
     }
 
     // Set ok result

--- a/Application/GCodeGeneratorScr.cpp
+++ b/Application/GCodeGeneratorScr.cpp
@@ -182,6 +182,10 @@ Result GCodeGeneratorScr::ProcessMenuOkCallback(GCodeGeneratorScr* obj_ptr, void
                 // Show message box with request
                 ths.msg_box.Show(10000u);
               }
+              // Interpreter is done with the output buffer which belongs to
+              // program sender from now on: clear the pointer so a later
+              // variable reset(Cancel) or error report can't write into it
+              ths.interpreter.SetOutputBuf(nullptr, 0);
             }
             else
             {
@@ -280,6 +284,9 @@ Result GCodeGeneratorScr::ProcessMenuOkCallback(GCodeGeneratorScr* obj_ptr, void
       {
         // Get file size
         uint32_t fsize = f_size(&SDFile) + 1u;
+        // Clear interpreter output pointer: it may still reference the
+        // buffer released below and must not be written after the free
+        ths.interpreter.SetOutputBuf(nullptr, 0);
         // Release buffer in program sender before allocation
         ProgramSender::GetInstance().ReleaseDataPointer();
         // Allocate memory for data and check if allocation was successful
@@ -291,6 +298,9 @@ Result GCodeGeneratorScr::ProcessMenuOkCallback(GCodeGeneratorScr* obj_ptr, void
           fres = f_read(&SDFile, ths.p_text, fsize, &wbytes);
           // And null-terminator to it
           ths.p_text[wbytes] = 0x00;
+          // Read result: on SD error f_read() can return partial data and
+          // a partially read script must not be interpreted
+          bool loaded = ((fres == FR_OK) && (wbytes == fsize - 1u));
 
           // Set program buffer
           ths.interpreter.SetPgmBuffer(ths.p_text, fsize);
@@ -302,7 +312,7 @@ Result GCodeGeneratorScr::ProcessMenuOkCallback(GCodeGeneratorScr* obj_ptr, void
           ths.interpreter.SetOutputBuf(txt, size);
 
           // Prescan program to find all global variables and functions
-          if(ths.interpreter.Prescan()) // If prescan successful
+          if(loaded && ths.interpreter.Prescan()) // If read and prescan successful
           {
             uint32_t i = 0u;
             // Copy string. Last array element reserved for null-terminator
@@ -325,15 +335,20 @@ Result GCodeGeneratorScr::ProcessMenuOkCallback(GCodeGeneratorScr* obj_ptr, void
             ths.UpdateMenuStrings();
             ths.menu.Show(100);
             ths.tabs.SetSelectedTab(0u);
+            // Interpreter is done with the output buffer - clear the pointer
+            // before the buffer is released, otherwise a later variable
+            // reset(Cancel) or error report would write into freed memory
+            ths.interpreter.SetOutputBuf(nullptr, 0);
             // We don't need this data pointer - it will allocate again before execution
             ProgramSender::GetInstance().ReleaseDataPointer();
           }
           else
           {
-            // If prescan failed - release allocated memory
+            // If read or prescan failed - release allocated memory
             ths.ReleaseDataPointer();
-            // Display message box with an error
-            ths.msg_box.Setup("Error", txt);
+            // Display message box with an error: for failed prescan the
+            // interpreter wrote error text into the output buffer
+            ths.msg_box.Setup("Error", loaded ? txt : "Can't read the file!\n");
             // Show message box with request
             ths.msg_box.Show(10000u);
           }
@@ -533,6 +548,9 @@ Result GCodeGeneratorScr::ProcessCallback(const void* ptr)
   // Process message box with an error
   else if(ptr == &msg_box)
   {
+    // Interpreter may still hold the buffer as the output(error text was
+    // written into it) - clear the pointer before the buffer is released
+    interpreter.SetOutputBuf(nullptr, 0);
     // Release buffer in program sender after message box with an error cleared
     ProgramSender::GetInstance().ReleaseDataPointer();
   }

--- a/Application/GrblComm.cpp
+++ b/Application/GrblComm.cpp
@@ -725,7 +725,7 @@ Result GrblComm::Jog(uint8_t axis, int32_t distance, uint32_t feed_x100, bool is
 // *****************************************************************************
 // ***   Public: JogInMachineCoodinates   **************************************
 // *****************************************************************************
-Result GrblComm::JogInMachineCoodinates(uint8_t axis, int32_t distance, uint32_t feed)
+Result GrblComm::JogInMachineCoodinates(uint8_t axis, int32_t distance, uint32_t feed_x100)
 {
   Result result = Result::ERR_BAD_PARAMETER;
 
@@ -739,12 +739,15 @@ Result GrblComm::JogInMachineCoodinates(uint8_t axis, int32_t distance, uint32_t
       // Set ID for command
       msg.id = GetNextId();
 
-      // Buffer for distance string
+      // Buffers for distance and feed strings
       char distance_str[16u];
-      // Convert distance value to string
+      char feed_str[16u];
+      // Convert distance & feed values to strings. Feed passed as value * 100
+      // to keep resolution for slow feeds in inches/min(imperial system).
       ValueToString(distance_str, NumberOf(distance_str), distance, GetReportUnitsScaler(axis));
+      ValueToString(feed_str, NumberOf(feed_str), feed_x100, 100);
       // Create jog string
-      snprintf((char*)msg.cmd, NumberOf(msg.cmd), "$J=%sG53G90%s%sF%lu\r", GetMeasurementSystemGcode(), axis_str[axis], distance_str, feed);
+      snprintf((char*)msg.cmd, NumberOf(msg.cmd), "$J=%sG53G90%s%sF%s\r", GetMeasurementSystemGcode(), axis_str[axis], distance_str, feed_str);
 
       // Send message
       result = SendTaskMessage(&msg);
@@ -974,7 +977,7 @@ Result GrblComm::MoveAxis(uint8_t axis, int32_t distance, uint32_t feed_x100, ui
 // *****************************************************************************
 // ***   Public: ProbeAxisTowardWorkpiece   ************************************
 // *****************************************************************************
-Result GrblComm::ProbeAxisTowardWorkpiece(uint8_t axis, int32_t position, uint32_t feed, uint32_t &id, bool strict)
+Result GrblComm::ProbeAxisTowardWorkpiece(uint8_t axis, int32_t position, uint32_t feed_x100, uint32_t &id, bool strict)
 {
   Result result = Result::ERR_BAD_PARAMETER;
 
@@ -988,18 +991,21 @@ Result GrblComm::ProbeAxisTowardWorkpiece(uint8_t axis, int32_t position, uint32
       // Set ID for command
       msg.id = GetNextId();
 
-      // Buffer for distance string
+      // Buffers for distance and feed strings
       char position_str[16u];
-      // Convert distance value to string
+      char feed_str[16u];
+      // Convert distance & feed values to strings. Feed passed as value * 100
+      // to keep resolution for slow feeds in inches/min(imperial system).
       ValueToString(position_str, NumberOf(position_str), position, GetReportUnitsScaler(axis));
+      ValueToString(feed_str, NumberOf(feed_str), feed_x100, 100);
       // Create Set Axis command. Strict uses .2 to produce alarm, non-strict uses .3 to avoid alarm.
       if(strict)
       {
-        snprintf((char*)msg.cmd, NumberOf(msg.cmd), "G90%sG38.2%s%sF%lu\r", GetMeasurementSystemGcode(), axis_str[axis], position_str, feed);
+        snprintf((char*)msg.cmd, NumberOf(msg.cmd), "G90%sG38.2%s%sF%s\r", GetMeasurementSystemGcode(), axis_str[axis], position_str, feed_str);
       }
       else
       {
-        snprintf((char*)msg.cmd, NumberOf(msg.cmd), "G90%sG38.3%s%sF%lu\r", GetMeasurementSystemGcode(), axis_str[axis], position_str, feed);
+        snprintf((char*)msg.cmd, NumberOf(msg.cmd), "G90%sG38.3%s%sF%s\r", GetMeasurementSystemGcode(), axis_str[axis], position_str, feed_str);
       }
 
       // Send message
@@ -1020,7 +1026,7 @@ Result GrblComm::ProbeAxisTowardWorkpiece(uint8_t axis, int32_t position, uint32
 // *****************************************************************************
 // ***   Public: ProbeAxisAwayFromWorkpiece   **********************************
 // *****************************************************************************
-Result GrblComm::ProbeAxisAwayFromWorkpiece(uint8_t axis, int32_t position, uint32_t feed, uint32_t &id)
+Result GrblComm::ProbeAxisAwayFromWorkpiece(uint8_t axis, int32_t position, uint32_t feed_x100, uint32_t &id)
 {
   Result result = Result::ERR_BAD_PARAMETER;
 
@@ -1034,12 +1040,15 @@ Result GrblComm::ProbeAxisAwayFromWorkpiece(uint8_t axis, int32_t position, uint
       // Set ID for command
       msg.id = GetNextId();
 
-      // Buffer for distance string
+      // Buffers for distance and feed strings
       char position_str[16u];
-      // Convert distance value to string
+      char feed_str[16u];
+      // Convert distance & feed values to strings. Feed passed as value * 100
+      // to keep resolution for slow feeds in inches/min(imperial system).
       ValueToString(position_str, NumberOf(position_str), position, GetReportUnitsScaler(axis));
+      ValueToString(feed_str, NumberOf(feed_str), feed_x100, 100);
       // Create Set Axis command
-      snprintf((char*)msg.cmd, NumberOf(msg.cmd), "G90%sG38.4%s%sF%lu\r", GetMeasurementSystemGcode(), axis_str[axis], position_str, feed);
+      snprintf((char*)msg.cmd, NumberOf(msg.cmd), "G90%sG38.4%s%sF%s\r", GetMeasurementSystemGcode(), axis_str[axis], position_str, feed_str);
 
       // Send message
       result = SendTaskMessage(&msg);
@@ -1256,18 +1265,24 @@ char* GrblComm::ValueToStringWithUnits(char* buf, uint32_t buf_size, int32_t val
   // If truncate requested - remove trailing zeros after point
   if(truncate && (scaler > 1))
   {
-    // Get string length
-    uint32_t len = strlen(buf);
-    // Trim only if string isn't empty to prevent index underflow
-    if(len > 0u)
+    // Find the decimal point: only fractional zeros after it may be trimmed,
+    // trimming past it would eat integer digits(e.g. "10.000" -> "1").
+    char* point = strchr(buf, '.');
+    // Trim only if the number has a fractional part
+    if(point != nullptr)
     {
-      // Index of the last character
-      len--;
-      // Replace all trailing zeros and point to null-terminator
-      while(len && ((buf[len] == '0') || (buf[len] == '.')))
+      // Index of the last character. String isn't empty since point is found.
+      uint32_t len = strlen(buf) - 1u;
+      // Replace trailing zeros with null-terminator, but not beyond the point
+      while((&buf[len] > point) && (buf[len] == '0'))
       {
         buf[len] = '\0';
         len--;
+      }
+      // If the whole fractional part was trimmed - remove the point as well
+      if(&buf[len] == point)
+      {
+        buf[len] = '\0';
       }
     }
   }

--- a/Application/GrblComm.cpp
+++ b/Application/GrblComm.cpp
@@ -135,8 +135,12 @@ Result GrblComm::TimerExpired(uint32_t missed_cnt)
     status_tx_timestamp = RtosTick::GetTimeMs();
     // Status received flag
     status_received = false;
+    // Copy command to the dedicated transmit byte: Write() is DMA based and
+    // reads memory asynchronously, so transmitting from
+    // status_request_command directly would send the reverted value.
+    status_request_tx_byte = status_request_command;
     // Request status
-    uart->Write(&status_request_command, 1u);
+    uart->Write(&status_request_tx_byte, 1u);
     // Revert status command to short one
     status_request_command = CMD_STATUS_REPORT_LEGACY;
 

--- a/Application/GrblComm.h
+++ b/Application/GrblComm.h
@@ -468,6 +468,22 @@ class GrblComm : public AppTask
     inline int32_t ConvertUnitsToMetric(int32_t units) {return (IsMetric() ? units : units * 254 / 100);}
 
     // *************************************************************************
+    // ***   Public: ConvertMetricFeedToUnitsX100 function   *******************
+    // *************************************************************************
+    // Convert feed in mm/min to feed * 100 in current report units(mm/min or
+    // inches/min). Feed conversion is 1 inch = 25.4 mm, unlike position
+    // conversion in ConvertMetricToUnits() which converts between fixed point
+    // representations(1 um and 0.0001 inch).
+    inline uint32_t ConvertMetricFeedToUnitsX100(uint32_t feed) {return (IsMetric() ? feed * 100u : feed * 1000u / 254u);}
+
+    // *************************************************************************
+    // ***   Public: ConvertUnitsFeedX100ToMetric function   *******************
+    // *************************************************************************
+    // Convert feed * 100 in current report units back to whole mm/min. Result
+    // is rounded to make the conversion above reversible.
+    inline uint32_t ConvertUnitsFeedX100ToMetric(uint32_t feed_x100) {return (IsMetric() ? (feed_x100 + 50u) / 100u : (feed_x100 * 254u + 500u) / 1000u);}
+
+    // *************************************************************************
     // ***   Public: GetUnits function   ***************************************
     // *************************************************************************
     inline static const char* GetUnits(uint8_t ms) {return units[ms];}
@@ -815,12 +831,12 @@ class GrblComm : public AppTask
     // *************************************************************************
     // ***   Public: ProbeAxisTowardWorkpiece   ********************************
     // *************************************************************************
-    Result ProbeAxisTowardWorkpiece(uint8_t axis, int32_t position, uint32_t feed, uint32_t &id, bool strict = true);
+    Result ProbeAxisTowardWorkpiece(uint8_t axis, int32_t position, uint32_t feed_x100, uint32_t &id, bool strict = true);
 
     // *************************************************************************
     // ***   Public: ProbeAxisAwayFromWorkpiece   ******************************
     // *************************************************************************
-    Result ProbeAxisAwayFromWorkpiece(uint8_t axis, int32_t position, uint32_t feed, uint32_t &id);
+    Result ProbeAxisAwayFromWorkpiece(uint8_t axis, int32_t position, uint32_t feed_x100, uint32_t &id);
 
     // *************************************************************************
     // ***   Public: SetToolLengthOffset   *************************************

--- a/Application/GrblComm.h
+++ b/Application/GrblComm.h
@@ -900,6 +900,11 @@ class GrblComm : public AppTask
     // Command to request status. On MPG gain control request it would be replaced
     // request full status report command. Then it will reverted back.
     uint8_t status_request_command = CMD_STATUS_REPORT_LEGACY;
+    // Copy of the status request command used as the transmit buffer: UART
+    // Write() is DMA based and reads memory asynchronously, so it can't
+    // transmit directly from status_request_command which is reverted right
+    // after the write call.
+    uint8_t status_request_tx_byte = CMD_STATUS_REPORT_LEGACY;
     // Flag show that status received after request. New status request will
     // not send until previous response received.
     bool status_received = true;

--- a/Application/Little-C.cpp
+++ b/Application/Little-C.cpp
@@ -54,7 +54,7 @@ bool LittleC::SetOutputBuf(char* p_obuf, int size)
   output_size = size;
   cur_pos = 0;
   // Return true if buffer is exist
-  return ((p_buf != nullptr) && (size != 0));
+  return ((p_obuf != nullptr) && (size != 0));
 }
 
 // *****************************************************************************

--- a/Application/OverrideCtrlScr.cpp
+++ b/Application/OverrideCtrlScr.cpp
@@ -130,6 +130,13 @@ Result OverrideCtrlScr::Show()
   // Stop button
   right_btn.Show(102);
 
+  // Clear override change values: encoder clicks buffered between the last
+  // timer tick and Hide() are never consumed while the screen is hidden and
+  // would send unexpected override steps on the first ticks after the screen
+  // is shown again.
+  feed_val = 0;
+  speed_val = 0;
+
   // Set encoder callback handler
   InputDrv::GetInstance().AddEncoderCallbackHandler(AppTask::GetCurrent(), reinterpret_cast<CallbackPtr>(ProcessEncoderCallback), this, enc_cble);
 

--- a/Application/ProbeScr.cpp
+++ b/Application/ProbeScr.cpp
@@ -1709,6 +1709,20 @@ Result ToolOffsetTab::TimerExpired(uint32_t interval)
   // Set actual tool offset
   dw_tool.SetNumber(grbl_comm.GetToolLengthOffset());
 
+  // Error check - if state isn't IDLE, RUN or HOLD we should abort probing
+  // sequence: probe alarm(missed tool setter, e-stop, limit) produces
+  // neither "ok" nor "error" response, so the sequence would wait for the
+  // command result forever with the screen change disabled.
+  if((grbl_comm.GetState() != GrblComm::IDLE) && (grbl_comm.GetState() != GrblComm::RUN) && (grbl_comm.GetState() != GrblComm::HOLD))
+  {
+    // Clear cmd
+    cmd_id = 0u;
+    // Clear state
+    state = PROBE_CNT;
+    // Enable screen change
+    ProbeScr::GetInstance().EnableScreenChange();
+  }
+
   // If we in probing cycle
   if(state != PROBE_CNT)
   {

--- a/Application/ProbeScr.cpp
+++ b/Application/ProbeScr.cpp
@@ -795,8 +795,10 @@ Result CenterFinderTab::ProcessEncoderCallback(CenterFinderTab* obj_ptr, void* p
     // Cast pointer itself to integer value
     int32_t enc_val = (int32_t)ptr;
 
-    // Process it
-    if(enc_val != 0)
+    // Process it. Change anything only if probing isn't started: the probing
+    // sequence reads these windows at every step, so a change mid-sequence
+    // would corrupt already calculated motion targets.
+    if((enc_val != 0) && (ths.state == PROBE_CNT))
     {
       // Change clearance
       if(ths.dw_clearance.IsShow() && ths.dw_clearance.IsSelected())
@@ -852,7 +854,7 @@ Result CenterFinderTab::ProbeInsideLineSequence(probe_line_state_t& state, uint8
     // Get current axis position to return probe back after probing
     safe_pos = grbl_comm.GetAxisPosition(axis);
     // Try to probe axis +/- 1 meter at search feed
-    result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) + (grbl_comm.ConvertMetricToUnits(1000000) * dir), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+    result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) + (grbl_comm.ConvertMetricToUnits(1000000) * dir), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
     // Set next state
     state = PROBE_LINE_FAST;
   }
@@ -861,14 +863,14 @@ Result CenterFinderTab::ProbeInsideLineSequence(probe_line_state_t& state, uint8
     // Get probe axis position
     measured_pos = grbl_comm.GetProbePosition(axis);
     // Move away from workpiece at search feed
-    result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos, grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+    result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos, grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
     // Set next state
     state = PROBE_LINE_FAST_RETURN;
   }
   else if(state == PROBE_LINE_FAST_RETURN)
   {
     // Try to probe axis at measured position +/- 1 mm at lock feed
-    result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (grbl_comm.ConvertMetricToUnits(1000) * dir), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_LOCK_FEED)), cmd_id);
+    result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (grbl_comm.ConvertMetricToUnits(1000) * dir), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_LOCK_FEED)), cmd_id);
     // Set next state
     state = PROBE_LINE_SLOW;
   }
@@ -930,7 +932,7 @@ Result CenterFinderTab::ProbeOutsideLineSequence(probe_line_state_t& state, uint
   else if(state == PROBE_LINE_MOVE)
   {
     // Dive before probing. We use probing command to avoid probe damage if distance is incorrect.
-    result = grbl_comm.ProbeAxisTowardWorkpiece(GrblComm::AXIS_Z, z_safe_pos - dive, grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id, false);
+    result = grbl_comm.ProbeAxisTowardWorkpiece(GrblComm::AXIS_Z, z_safe_pos - dive, grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id, false);
     // Set next state
     state = PROBE_LINE_DIVE;
   }
@@ -957,7 +959,7 @@ Result CenterFinderTab::ProbeOutsideLineSequence(probe_line_state_t& state, uint
     else
     {
       // Try to probe axis +/- 1 meter at search feed
-      result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) + (grbl_comm.ConvertMetricToUnits(1000000) * (-dir)), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+      result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) + (grbl_comm.ConvertMetricToUnits(1000000) * (-dir)), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
       // Set next state
       state = PROBE_LINE_FAST;
     }
@@ -970,7 +972,7 @@ Result CenterFinderTab::ProbeOutsideLineSequence(probe_line_state_t& state, uint
     // Get probe axis position
     measured_pos = grbl_comm.GetProbePosition(axis);
     // Move away from workpiece at search feed
-    result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos + len * dir, grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+    result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos + len * dir, grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
     // Set next state
     state = PROBE_LINE_FAST_RETURN;
   }
@@ -980,7 +982,7 @@ Result CenterFinderTab::ProbeOutsideLineSequence(probe_line_state_t& state, uint
   else if(state == PROBE_LINE_FAST_RETURN)
   {
     // Try to probe axis at measured position +/- 1 mm at lock feed
-    result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (grbl_comm.ConvertMetricToUnits(1000) * (-dir)), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_LOCK_FEED)), cmd_id);
+    result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (grbl_comm.ConvertMetricToUnits(1000) * (-dir)), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_LOCK_FEED)), cmd_id);
     // Set next state
     state = PROBE_LINE_SLOW;
   }
@@ -1259,7 +1261,7 @@ Result EdgeFinderTab::TimerExpired(uint32_t interval)
         // Get current axis position to return probe back after probing
         safe_pos = grbl_comm.GetAxisPosition(axis);
         // Try to probe axis +/- 1 meter at search feed
-        result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) + (grbl_comm.ConvertMetricToUnits(1000000) * dir), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+        result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) + (grbl_comm.ConvertMetricToUnits(1000000) * dir), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
         // Set next state
         state = PROBE_FAST;
       }
@@ -1268,14 +1270,14 @@ Result EdgeFinderTab::TimerExpired(uint32_t interval)
         // Get probe axis position
         measured_pos = grbl_comm.GetProbePosition(axis);
         // Move away from workpiece at search feed
-        result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos, grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+        result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos, grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
         // Set next state
         state = PROBE_FAST_RETURN;
       }
       else if(state == PROBE_FAST_RETURN)
       {
         // Try to probe axis at measured position +/- 1 mm at lock feed
-        result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (grbl_comm.ConvertMetricToUnits(1000) * dir), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_LOCK_FEED)), cmd_id);
+        result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (grbl_comm.ConvertMetricToUnits(1000) * dir), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_LOCK_FEED)), cmd_id);
         // Set next state
         state = PROBE_SLOW;
       }
@@ -1293,7 +1295,7 @@ Result EdgeFinderTab::TimerExpired(uint32_t interval)
           first_iteration_measured_pos = measured_pos;
         }
         // Move away from workpiece at search feed
-        result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos, grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
+        result = grbl_comm.ProbeAxisAwayFromWorkpiece(axis, safe_pos, grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id);
         // Return after axis probing
         state = PROBE_SLOW_RETURN;
       }
@@ -1324,7 +1326,7 @@ Result EdgeFinderTab::TimerExpired(uint32_t interval)
         else if(precise_btn.GetPressed() && (iteration == PROBE_ITERATION_FIRST))
         {
           // Move probe away work piece to give more space to rotate the probe
-          result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) - (dw_tip_diameter.GetNumber() / 2 * dir), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id, false);
+          result = grbl_comm.ProbeAxisTowardWorkpiece(axis, grbl_comm.GetAxisPosition(axis) - (dw_tip_diameter.GetNumber() / 2 * dir), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id, false);
           // Set Message Box parameters and callback
           msg_box.Setup("Action needed", "Turn probe 180 degrees\nand press continue");
           // Show message box with request
@@ -1345,7 +1347,7 @@ Result EdgeFinderTab::TimerExpired(uint32_t interval)
         // Use probe command to move axis over the edge. Strict flag set to false
         // because we don't expect probe to be triggered, we using it as safety
         // to prevent probe damage in case clearance not big enough.
-        result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (dw_tip_diameter.GetNumber() / 2 * dir), grbl_comm.ConvertMetricToUnits(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id, false);
+        result = grbl_comm.ProbeAxisTowardWorkpiece(axis, measured_pos + (dw_tip_diameter.GetNumber() / 2 * dir), grbl_comm.ConvertMetricFeedToUnitsX100(NVM::GetInstance().GetValue(NVM::PROBE_SEARCH_FEED)), cmd_id, false);
         // Probe max state - done sequence
         state = PROBE_RETURN;
       }
@@ -1526,8 +1528,11 @@ Result EdgeFinderTab::ProcessEncoderCallback(EdgeFinderTab* obj_ptr, void* ptr)
     // Cast pointer itself to integer value
     int32_t enc_val = (int32_t)ptr;
 
-    // Process it
-    if(enc_val != 0)
+    // Process it. Change anything only if probing isn't started: the probing
+    // sequence reads these windows at every step, so a change mid-sequence
+    // would corrupt already calculated motion targets and the tip diameter
+    // stored in NVM.
+    if((enc_val != 0) && (ths.state == PROBE_CNT))
     {
       // Change clearance
       if(ths.dw_clearance.IsSelected())
@@ -1711,7 +1716,7 @@ Result ToolOffsetTab::TimerExpired(uint32_t interval)
     if(cmd_id == 0u)
     {
       // Try to probe Z axis -1 meter at feed 100 mm/min
-      result = grbl_comm.ProbeAxisTowardWorkpiece(GrblComm::AXIS_Z, grbl_comm.GetAxisPosition(GrblComm::AXIS_Z) - grbl_comm.ConvertMetricToUnits(1000000), grbl_comm.ConvertMetricToUnits(100u), cmd_id);
+      result = grbl_comm.ProbeAxisTowardWorkpiece(GrblComm::AXIS_Z, grbl_comm.GetAxisPosition(GrblComm::AXIS_Z) - grbl_comm.ConvertMetricToUnits(1000000), grbl_comm.ConvertMetricFeedToUnitsX100(100u), cmd_id);
       // Check result
       if(result == Result::ERR_CANNOT_EXECUTE)
       {
@@ -1748,7 +1753,7 @@ Result ToolOffsetTab::TimerExpired(uint32_t interval)
       if(result.IsGood())
       {
         // Move Z axis to the point before probing at feed 500 mm/min
-        grbl_comm.JogInMachineCoodinates(GrblComm::AXIS_Z, z_position, grbl_comm.ConvertMetricToUnits(500u));
+        grbl_comm.JogInMachineCoodinates(GrblComm::AXIS_Z, z_position, grbl_comm.ConvertMetricFeedToUnitsX100(500u));
         // Clear cmd
         cmd_id = 0u;
         // Clear state

--- a/Application/ProgramSender.cpp
+++ b/Application/ProgramSender.cpp
@@ -301,6 +301,20 @@ Result ProgramSender::TimerExpired(uint32_t interval)
                     text_box.AddLine(str);
                   }
                 }
+                else
+                {
+                  // Read failed but end of file isn't reached: SD error or
+                  // file isn't open anymore. Stop streaming, otherwise the
+                  // same selected line would be sent again on every tick.
+                  run = false;
+                  // Set finished flag to prevent further streaming attempts
+                  finished = true;
+                  // Show the reason in the text box
+                  text_box.AddLine("; ERROR: file read failed - STOPPED");
+                  // And in the message box
+                  Application::GetInstance().GetMsgBox().Setup("PROGRAM STOPPED", "File read error encountered\nduring streaming.\nRemaining program was skipped.");
+                  Application::GetInstance().GetMsgBox().Show(10000u);
+                }
               }
             }
             else
@@ -346,9 +360,10 @@ Result ProgramSender::TimerExpired(uint32_t interval)
   }
   else
   {
-    // Safety measure: allow run program only from the beginning
+    // Safety measure: allow run program only from the beginning and only
+    // if there is a program to run
     // TODO: add dialog box "Are you sure you want to run program from current position?" instead
-    if(text_box.GetSelect() == 0)
+    if((text_box.GetSelect() == 0) && (text_box.GetNumberOfLines() > 0))
     {
       left_btn.Enable();
     }
@@ -520,11 +535,25 @@ Result ProgramSender::ProcessMenuOkCallback(ProgramSender* obj_ptr, void* ptr)
         fres = f_read(&SDFile, ths.p_text, fsize, &wbytes);
         // And null-terminator to it
         ths.p_text[wbytes] = 0x00;
+        // Check read result: on SD error f_read() can return partial data
+        // which would be displayed and runnable as a valid program with the
+        // tail(possibly mid-line) missing
+        if((fres != FR_OK) || (wbytes != fsize - 1u))
+        {
+          // Release partially read data
+          ths.ReleaseDataPointer();
+          // Show an error message instead of the partially read program
+          ths.text_box.SetText("; File read error!");
+        }
         // Set text to text box
-        if(!ths.text_box.SetText(ths.p_text))
+        else if(!ths.text_box.SetText(ths.p_text))
         {
           // If program contains lines longer than 80 characters - show message
           ths.text_box.SetText("; Program contain lines longer\n\r; than 80 characters");
+        }
+        else
+        {
+          ; // Do nothing - MISRA rule
         }
         // Close file
         fres = f_close(&SDFile);
@@ -638,8 +667,11 @@ Result ProgramSender::ProcessCallback(const void* ptr)
   // button, we have to check if Run button is active.
   if(ptr == &left_btn)
   {
-    // We should run program only if it doesn't already run, we in control and state is Idle
-    if(!run && grbl_comm.IsInControl() && (grbl_comm.GetState() == GrblComm::IDLE))
+    // We should run program only if it doesn't already run, we in control,
+    // state is Idle and there is a program to run: without the line check
+    // Run with nothing loaded(or after the SD file was closed by leaving
+    // the screen) would stream empty commands indefinitely.
+    if(!run && grbl_comm.IsInControl() && (grbl_comm.GetState() == GrblComm::IDLE) && (text_box.GetNumberOfLines() > 0))
     {
       // Clear id to run program
       id = 0u;
@@ -810,14 +842,17 @@ char* ProgramSender::AllocateDataBuffer(uint32_t& size)
   // If size is zero
   if(size == 0u)
   {
-    // Get maximum available block size from FreeRTOS and use it
+    // Get maximum available block size from FreeRTOS and use it. Reserve
+    // heap block overhead, guarding against underflow for tiny blocks.
     HeapStats_t HeapStats;
     vPortGetHeapStats(&HeapStats);
-    size = HeapStats.xSizeOfLargestFreeBlockInBytes - 32u;
+    size = (HeapStats.xSizeOfLargestFreeBlockInBytes > 32u) ? (HeapStats.xSizeOfLargestFreeBlockInBytes - 32u) : 0u;
   }
 
-  // Allocate memory for data
-  p_text = new(std::nothrow) char[size];
+  // Allocate memory for data. Zero size is degenerate - nothing can be
+  // stored in such buffer, and writing the null-terminator below would be
+  // out of bounds.
+  p_text = (size != 0u) ? new(std::nothrow) char[size] : nullptr;
   // If allocation is successful
   if(p_text != nullptr)
   {

--- a/Application/RotaryTableScr.cpp
+++ b/Application/RotaryTableScr.cpp
@@ -291,57 +291,89 @@ Result RotaryTableScr::TimerExpired(uint32_t interval)
   // *** Process radius change *************************************************
   if(radius_change != 0)
   {
-    // Recalculate new current points using change in radius
-    FindNewPointByRadius(current_x, current_y, center_x, center_y, radius_change);
-    // Recalculate radius itself
-    radius = (uint32_t)(sqrt(pow(current_x - center_x, 2) + pow(current_y - center_y, 2)));
-    // Update radius window with new value
-    radius_dw.SetNumber(radius);
+    // Recalculate new current point using change in radius. Use copies:
+    // the model must be committed only if the controller accepts the move.
+    double new_x = current_x;
+    double new_y = current_y;
+    FindNewPointByRadius(new_x, new_y, center_x, center_y, radius_change);
     // Clear radius change
     radius_change = 0;
-    // Update start points
-    start_x = current_x;
-    start_y = current_y;
-    // Clear arc length
-    arc_length = 0;
-    // Set arc length
-    arc_dw.SetNumber(arc_length);
     // Move tool for new radius
-    result = grbl_comm.JogMultiple(start_x, start_y, grbl_comm.GetAxisPosition(GrblComm::AXIS_Z), feed, true);
+    result = grbl_comm.JogMultiple((int32_t)new_x, (int32_t)new_y, grbl_comm.GetAxisPosition(GrblComm::AXIS_Z), feed, true);
+    // Commit the model only if the command was accepted, otherwise the
+    // software position diverges from the machine and the next move would
+    // be computed from a phantom point.
+    if(result == Result::RESULT_OK)
+    {
+      // Save new point
+      current_x = new_x;
+      current_y = new_y;
+      // Recalculate radius itself
+      radius = (uint32_t)(sqrt(pow(current_x - center_x, 2) + pow(current_y - center_y, 2)));
+      // Update radius window with new value
+      radius_dw.SetNumber(radius);
+      // Update start points
+      start_x = current_x;
+      start_y = current_y;
+      // Clear arc length
+      arc_length = 0;
+      // Set arc length
+      arc_dw.SetNumber(arc_length);
+    }
   }
 
   // *** Process arc length change *********************************************
   if(arc_length != arc_dw.GetNumber())
   {
-    // Find difference between old and new length
-    int32_t diff = arc_dw.GetNumber() - arc_length;
-    // Update length window with new value
-    arc_dw.SetNumber(arc_length);
-
-    // Set current points to arc start for calculation
-    double new_x = start_x;
-    double new_y = start_y;
-    // Calculate new position
-    FindArcSecondPoint(new_x, new_y, center_x, center_y, abs(arc_length), arc_length >= 0);
-
-    // Since we have finite resolution in 1 um, we have to check if new point is the same as old point after round
-    if(((int32_t)new_x != (int32_t)current_x) || ((int32_t)new_y != (int32_t)current_y))
+    // Arc move is possible only with non-zero radius: the endpoint math
+    // divides the arc length by the radius, and zero radius(machine parked
+    // exactly at the center, e.g. right after the center was captured)
+    // produces NaN coordinates.
+    if(radius == 0)
     {
-      // Save new point
-      current_x = new_x;
-      current_y = new_y;
-      // Run Jog command
-      result = grbl_comm.JogArcXYR((int32_t)current_x, (int32_t)current_y, radius, feed, diff < 0, true);
+      // Revert the dialed value
+      arc_length = arc_dw.GetNumber();
     }
-
-    // *** TODO: REMOVE ! ******************************************************
+    else
     {
-//      double tpx = dpx;
-//      double tpy = dpy;
-//      FindArcSecondPoint(tpx, tpy, dcx, dcy, abs(dl), dl >= 0);
-//      cir.Move(tpx, tpy);
+      // Find difference between old and new length
+      int32_t diff = arc_dw.GetNumber() - arc_length;
+
+      // Set current points to arc start for calculation
+      double new_x = start_x;
+      double new_y = start_y;
+      // Calculate new position
+      FindArcSecondPoint(new_x, new_y, center_x, center_y, abs(arc_length), arc_length >= 0);
+
+      // Since we have finite resolution in 1 um, we have to check if new point is the same as old point after round
+      if(((int32_t)new_x != (int32_t)current_x) || ((int32_t)new_y != (int32_t)current_y))
+      {
+        // Run Jog command
+        result = grbl_comm.JogArcXYR((int32_t)new_x, (int32_t)new_y, radius, feed, diff < 0, true);
+        // Commit the model only if the command was accepted, otherwise the
+        // software position diverges from the machine and the next arc
+        // would be computed from a phantom point.
+        if(result == Result::RESULT_OK)
+        {
+          // Save new point
+          current_x = new_x;
+          current_y = new_y;
+          // Update length window with new value
+          arc_dw.SetNumber(arc_length);
+        }
+        else
+        {
+          // Command rejected(no control or wrong state) - revert the dialed
+          // value, otherwise the motion would fire later without user input.
+          arc_length = arc_dw.GetNumber();
+        }
+      }
+      else
+      {
+        // Same point after rounding - just sync the window
+        arc_dw.SetNumber(arc_length);
+      }
     }
-    // *** TODO: REMOVE ! ******************************************************
   }
 
   // Return result
@@ -489,11 +521,12 @@ Result RotaryTableScr::ProcessButtonCallback(RotaryTableScr* obj_ptr, void* ptr)
         // If button pressed
         if(btn.state == true)
         {
-          // Reset numbers with current position
-          for(uint32_t i = 0u; i < NumberOf(center_dw); i++)
-          {
-            ths.center_dw[i].SetNumber(ths.grbl_comm.GetAxisPosition(i));
-          }
+          // Capture current machine position as the rotation center. Members
+          // are authoritative: TimerExpired() syncs the windows from them,
+          // recalculates radius and clears arc length. Writing only the
+          // windows would be reverted on the next timer tick.
+          ths.center_x = ths.grbl_comm.GetAxisPosition(GrblComm::AXIS_X);
+          ths.center_y = ths.grbl_comm.GetAxisPosition(GrblComm::AXIS_Y);
         }
         // Set ok result
         result = Result::RESULT_OK;

--- a/Application/SettingsScr.cpp
+++ b/Application/SettingsScr.cpp
@@ -97,6 +97,10 @@ Result SettingsScr::Hide()
   // Delete buttons callback handler
   InputDrv::GetInstance().DeleteButtonsCallbackHandler(btn_cble);
 
+  // In case if it shown, we should hide it. Otherwise a stale box callback
+  // would be routed to the next screen and misinterpreted there.
+  change_box.Hide();
+
   // Hide menu
   menu.Hide();
   // Show tabs

--- a/Application/SettingsScr.cpp
+++ b/Application/SettingsScr.cpp
@@ -145,8 +145,23 @@ Result SettingsScr::ProcessCallback(const void* ptr)
       // Probe tab
       else if(tabs.GetSelectedTab() == PROBE_TAB)
       {
-        // Save value - probe parameters always saved as metric
-        nvm.SetValue((NVM::Parameters)(change_box.GetId() + NVM::PROBE_SEARCH_FEED), grbl_comm.ConvertUnitsToMetric(change_box.GetValue()));
+        // Convert menu index to NVM index
+        uint32_t nvm_idx = change_box.GetId() + NVM::PROBE_SEARCH_FEED;
+        // Check if edited parameter is one of the probe feeds
+        if((nvm_idx == NVM::PROBE_SEARCH_FEED) || (nvm_idx == NVM::PROBE_LOCK_FEED))
+        {
+          // Value edited as whole mm/min in metric and as inches/min * 100 in imperial
+          int32_t feed = grbl_comm.IsMetric() ? change_box.GetValue() : (int32_t)grbl_comm.ConvertUnitsFeedX100ToMetric(change_box.GetValue());
+          // Feed is always stored as whole mm/min, zero feed is invalid
+          if(feed < 1) feed = 1;
+          // Save value
+          nvm.SetValue((NVM::Parameters)(nvm_idx), feed);
+        }
+        else
+        {
+          // Save value - probe parameters always saved as metric
+          nvm.SetValue((NVM::Parameters)(nvm_idx), grbl_comm.ConvertUnitsToMetric(change_box.GetValue()));
+        }
       }
       else
       {
@@ -267,16 +282,22 @@ Result SettingsScr::ProcessMenuCallback(SettingsScr* obj_ptr, void* ptr)
       // Units and precision variables
       const char* units = nullptr;
       uint32_t precision = 0;
+      // Value in display units
+      int32_t value = 0;
 
       if((nvm_idx == NVM::PROBE_BALL_TIP) || (nvm_idx == NVM::PROBE_POS_DEVIATION))
       {
         units = ths.grbl_comm.GetReportUnits();
         precision = ths.grbl_comm.GetReportUnitsPrecision();
+        value = ths.grbl_comm.ConvertMetricToUnits(ths.nvm.GetValue((NVM::Parameters)(nvm_idx)));
       }
       else if((nvm_idx == NVM::PROBE_SEARCH_FEED) || (nvm_idx == NVM::PROBE_LOCK_FEED))
       {
         units = ths.grbl_comm.GetReportSpeedUnits();
-        precision = 0;
+        // Feed edited as whole mm/min in metric and as inches/min with two
+        // decimal places in imperial(1 mm/min is only ~0.04 inches/min)
+        precision = ths.grbl_comm.IsMetric() ? 0u : 2u;
+        value = ths.grbl_comm.IsMetric() ? ths.nvm.GetValue((NVM::Parameters)(nvm_idx)) : (int32_t)ths.grbl_comm.ConvertMetricFeedToUnitsX100(ths.nvm.GetValue((NVM::Parameters)(nvm_idx)));
       }
       else
       {
@@ -287,7 +308,7 @@ Result SettingsScr::ProcessMenuCallback(SettingsScr* obj_ptr, void* ptr)
       if(units != nullptr)
       {
         // Setup object to change numerical parameters, title scale set to 1
-        ths.change_box.Setup(ths.menu_strings[nvm_idx], units, ths.grbl_comm.ConvertMetricToUnits(ths.nvm.GetValue((NVM::Parameters)(nvm_idx))) , 1, 10000, precision, 1u);
+        ths.change_box.Setup(ths.menu_strings[nvm_idx], units, value, 1, 10000, precision, 1u);
         // Set AppTask
         ths.change_box.SetCallback(AppTask::GetCurrent());
         // Save axis index as ID
@@ -362,7 +383,9 @@ Result SettingsScr::ProcessButtonCallback(SettingsScr* obj_ptr, void* ptr)
 // *****************************************************************************
 void SettingsScr::UpdateStrings(void)
 {
-  char tmp_str[16u] = {0};
+  // Buffer must fit the longest string: "393.70 inches/min" for feed
+  // converted from 10000 mm/min maximum
+  char tmp_str[20u] = {0};
   // Count for menu
   uint32_t cnt = 0;
   // General tab
@@ -395,8 +418,8 @@ void SettingsScr::UpdateStrings(void)
   else if(tabs.GetSelectedTab() == PROBE_TAB)
   {
     // ORDER OF STRINGS IN THIS ARRAY MUST EXACT MATCHED TO NVM::Parameters
-    menu.CreateString(menu_items[cnt++], menu_strings[NVM::PROBE_SEARCH_FEED],   grbl_comm.ValueToStringWithScalerAndUnits(tmp_str, NumberOf(tmp_str), grbl_comm.ConvertMetricToUnits(nvm.GetValue(NVM::PROBE_SEARCH_FEED)), grbl_comm.GetReportSpeedScaler(), grbl_comm.GetReportSpeedUnits()));
-    menu.CreateString(menu_items[cnt++], menu_strings[NVM::PROBE_LOCK_FEED],     grbl_comm.ValueToStringWithScalerAndUnits(tmp_str, NumberOf(tmp_str), grbl_comm.ConvertMetricToUnits(nvm.GetValue(NVM::PROBE_LOCK_FEED)), grbl_comm.GetReportSpeedScaler(), grbl_comm.GetReportSpeedUnits()));
+    menu.CreateString(menu_items[cnt++], menu_strings[NVM::PROBE_SEARCH_FEED],   grbl_comm.ValueToStringWithScalerAndUnits(tmp_str, NumberOf(tmp_str), grbl_comm.ConvertMetricFeedToUnitsX100(nvm.GetValue(NVM::PROBE_SEARCH_FEED)), 100, grbl_comm.GetReportSpeedUnits(), true));
+    menu.CreateString(menu_items[cnt++], menu_strings[NVM::PROBE_LOCK_FEED],     grbl_comm.ValueToStringWithScalerAndUnits(tmp_str, NumberOf(tmp_str), grbl_comm.ConvertMetricFeedToUnitsX100(nvm.GetValue(NVM::PROBE_LOCK_FEED)), 100, grbl_comm.GetReportSpeedUnits(), true));
     menu.CreateString(menu_items[cnt++], menu_strings[NVM::PROBE_POS_DEVIATION], grbl_comm.ValueToStringWithScalerAndUnits(tmp_str, NumberOf(tmp_str), grbl_comm.ConvertMetricToUnits(nvm.GetValue(NVM::PROBE_POS_DEVIATION)), grbl_comm.GetReportUnitsScaler(), grbl_comm.GetReportUnits()));
     menu.CreateString(menu_items[cnt++], menu_strings[NVM::PROBE_BALL_TIP],      grbl_comm.ValueToStringWithScalerAndUnits(tmp_str, NumberOf(tmp_str), grbl_comm.ConvertMetricToUnits(nvm.GetValue(NVM::PROBE_BALL_TIP)), grbl_comm.GetReportUnitsScaler(), grbl_comm.GetReportUnits()));
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Firmware for the **SmartPendant** — a touchscreen MPG/DRO pendant for **grblHAL** CNC controllers. Target MCU is an **STM32F411CEU** (WeAct BlackPill). It drives a 480×320 ILI9488 SPI display with an FT6236 capacitive touch controller, a 100 PPR quadrature handwheel, three buttons, a buzzer, and MB85RC256V FRAM for settings. It talks to the grblHAL controller over UART configured in **"MPG & DRO mode"**.
+
+## Repository setup (do this first)
+
+`DevCore/` is a **git submodule** (https://github.com/nickshl/DevCore.git) and is **not vendored** in this repo. The base framework (`AppTask`, `DisplayDrv`, `SoundDrv`, UI widgets `UiButton`/`String`/`DataWindow`, `RtosTick`, HAL wrappers `StHal*`, display/touch/eeprom drivers, fonts) all live there.
+
+```
+git submodule update --init --recursive     # if the repo was cloned without --recurse-submodules
+```
+
+The base classes that `Application/` code inherits from and calls into are defined under `DevCore/` (see the include dirs in `CMakeLists.txt`). When a symbol isn't found in `Application/`, look in `DevCore/`.
+
+## Building
+
+Two supported paths (see `README.md` for full detail):
+
+- **STM32CubeIDE** — import the project (`.cproject`/`.project`), build, flash with STM32CubeProgrammer.
+- **CMake + arm-none-eabi** (CMake ≥ 4.0.0):
+  ```
+  mkdir build && cd build
+  cmake -DCMAKE_TOOLCHAIN_FILE=./cmake/arm_none_eabi_gcc.cmake -DCMAKE_BUILD_TYPE=Debug ..
+  make
+  ```
+  `CMakeLists.txt` globs sources from `DevCore/ Drivers/ Middlewares/ Src/ Startup/ Application/`. Key compile defs: `STM32F411xE`, `USE_HAL_DRIVER`, `SWAP_BUTTONS=1`. Links against the flash linker script `STM32F411CEUX_FLASH.ld`. Post-build produces `.elf`, `.hex`, `.bin`, `.lst`, and a size report.
+
+There are **no unit tests** and no host build — this is bare-metal firmware; the only "run" is flashing hardware. Verification is manual on-device.
+
+## Flashing / bootloader entry
+
+From **v0.027.0** on, holding the **top-edge (MPG / USR) button** at power-on calibrates the internal RC oscillator and jumps to the STM32 system bootloader (DFU over USB-C) — see `Bootloader()` / `CalibrateHSI()` in `AppMain.cpp`. Older units use the BOOT0 button. Precompiled firmware lives in `Release/`.
+
+## Architecture
+
+### Startup (`Application/AppMain.cpp`)
+`AppMain()` is the C entry point called from the CubeMX-generated `Src/` code. It: auto-detects the crystal (8 vs 25 MHz) and configures the PLL; checks the USR button for bootloader entry; instantiates HAL-wrapper objects for every peripheral (`StHalSpi/Iic/Uart/Gpio`, `ILI9488`, `FT6236`, `Eeprom24`); then starts the FreeRTOS tasks: `NVM`, `DisplayDrv`, `SoundDrv`, `InputDrv`, and either **`Tetris`** (if the left-up button is held at boot — an easter egg) or the normal **`GrblComm` + `Application`** pair.
+
+### Task model
+Everything of substance is a **singleton FreeRTOS task** subclassing `AppTask` (from DevCore), accessed via `X::GetInstance()`. Tasks override `Setup()`, `TimerExpired(interval)`, `ProcessMessage()`, and `ProcessCallback(ptr)`, and return a `Result`. Cross-task calls are marshaled onto the target task via `AppTask::Callback(...)` so work runs in the right task context.
+
+### Screens (`IScreen`)
+The UI is a stack of screens implementing `Application/IScreen.h` (`Setup/Show/Hide/TimerExpired/ProcessCallback`). `Application` owns the screen array `scr[]` and switches between them with `ChangeScreen()` — which calls the old screen's `Hide()` **before** the new screen's `Show()`. Screen set depends on the controller's mode of operation (MILL vs LATHE). Navigation across top-level screens is via the `Header` page tabs. Screens include: DirectControl (MPG jog), OverrideCtrl, DelayControl (power feed), RotaryTable, ProgramSender (G-code sender), GCodeGenerator, Probe, Settings. `MsgBox` and `ChangeValueBox` are modal overlays shown on top of the active screen.
+
+### Input (`Application/InputDrv.*`)
+Timer-driven task reading the quadrature encoder, three GPIO buttons (debounced), and the FT6236 touch controller. Screens **register** encoder/button callbacks in `Show()` and **remove** them in `Hide()` via `Add/DeleteEncoderCallbackHandler` / `...ButtonsCallbackHandler`. Callbacks are stored in intrusive doubly-linked lists (`CallbackListEntry`). `Application` registers a persistent button handler at startup that is never removed; there is **no** persistent encoder handler.
+
+### grblHAL communication (`Application/GrblComm.*`) — the core, and the trickiest code
+Singleton UART task. Parses grblHAL real-time status reports (`<...>`), messages (`[...]`, e.g. `PRB:`/`TLO:`/`AXS:`), settings (`$...`), `ok`/`error:` responses. Maintains a **timing/handshake state machine** for gaining and releasing MPG control (`GainControl()`, `status_tx_timestamp`/`status_rx_timestamp`/`status_received`, `mpg_mode_request`, `respond_pending`). Axis data is stored in `[AXIS_CNT]` (=6, XYZABC) arrays; `number_of_axis` is what the controller reports; `GetLimitedNumberOfAxis(n)` is the safe accessor UI code uses when iterating axes. Uncomment `#define SEND_DATA_TO_USB` in `GrblComm.h` to mirror all controller traffic to a USB CDC serial port for debugging.
+
+### Settings / NVM (`Application/NVM.*`)
+Settings are a struct persisted to FRAM/EEPROM over I2C (`Eeprom24`), CRC-protected (`crc` is the last struct field; the CRC is computed over everything except itself). Parameters are addressed by the `NVM::Parameters` enum; `menu_strings[NVM::MAX_VALUES]` in `SettingsScr` is indexed by that **absolute** enum value. `EEP_VERSION` in `Version.h` guards layout migrations.
+
+### Script-driven G-code generation — the non-obvious subsystem
+`GCodeGeneratorScr` runs user **scripts** through an embedded C interpreter (`Application/Little-C.*`) to emit G-code programs, which are then handed to `ProgramSender`. Scripts live in `Scripts/` on the SD card: **`.ms` = mill**, **`.ls` = lathe** (filtered by the controller's mode of operation).
+
+Scripts are near-C and declare their tunable parameters as **global variable declarations with a structured trailing comment** that the generator parses to build the parameter-entry UI:
+
+```c
+int step = 3000;      // Step for pass; 1000; mm; 0; 1000000
+                      //   name        ; scaler; units; min; max
+int coolant = 0;      // Coolant; 0; Flood; Mist; None
+                      //   name  ; 0 == enum marker; enum labels...
+```
+
+`main()` emits G-code by calling built-ins: `println(...)`/`print(...)`/`puts(...)`/`putch(...)`, `GetAxisPosX/Y/Z()`, `abs()`, `sqrt()`. `println` accepts a literal string plus optional value args. The interpreter has a fixed 80-byte token buffer, a variable stack (`var_stack`, split into local-frame + global regions via `call_stack`/`functos`/`gvar_index`), and a function table. Generated output can optionally be written to `Result.nc` on the SD card when `NVM::SAVE_SCRIPT_RESULT` is enabled.
+
+## Conventions (match these when editing)
+
+- **File-scoped singletons**: `X::GetInstance()`. Members are initialized inline in the header.
+- Functions return `Result` (`RESULT_OK`, `ERR_*`); check it.
+- Unsigned literals get a `u` suffix (`300u`, `0u`); `nullptr` not `NULL`.
+- Array sizes via the `NumberOf(arr)` macro, never a hard-coded count.
+- MISRA-flavored style: exhaustive `if/else if/else`, with empty final branches written as `else { ; // Do nothing - MISRA rule }`.
+- Dense banner comments (`// ***`) precede every function; keep the format.
+- Time via `RtosTick::GetTimeMs()`; tick math uses unsigned wraparound subtraction — preserve that idiom.
+
+## Gotchas
+
+- **Bump the version** in `Application/Version.h` (`VERSION_MAJOR/MINOR/BUILD`) for a release build — there's a literal "DON'T FORGET TO CHANGE IT" note there.
+- **`Src/` and `Inc/` are CubeMX-generated** from `SmartPendant.ioc`. Regenerating from the `.ioc` will overwrite HAL init / peripheral config — hand edits there are fragile. Application logic belongs in `Application/`.
+- Malloc-failure hook is intentionally a no-op: `ProgramSender` relies on `new` returning `nullptr` when a program is too large to allocate — don't "fix" that hook to trap.
+- Robustness matters: this parses live, sometimes noisy, UART data and reads arbitrary SD card filenames — guard string parsing (`strchr`/length math) and array bounds; malformed input must not fault.


### PR DESCRIPTION
Claude analysis 

### Machine-safety bugs
S1. Imperial probing feeds are ~10× too fast — probe-breaking. Probe feeds are stored in mm/min and converted with ConvertMetricToUnits() (GrblComm.h:463) — a length converter (÷2.54 for µm→0.0001″), but feed conversion needs ÷25.4. The result is emitted raw as F%lu under G20, so 200 mm/min becomes F78 in/min ≈ 1981 mm/min. Affects every search/lock feed in ProbeScr.cpp (~13 call sites), and the tool-offset feeds at ProbeScr.cpp:1714 and 1751 are hardcoded, so the user can't even compensate in settings. On a $13=1 controller, "MEASURE BASE" plunges Z at ~10× the intended feed. Fix: add a dedicated metric→feed-units converter (÷25.4) and use it at all probe/jog feed sites.

S2. Handwheel changes spindle RPM with nothing selected. DirectControlScr::Show() deliberately sets axis = AXIS_CNT and deselects everything "to prevent accidental movement" — but the encoder callback's else-branch (DirectControlScr.cpp:546-553) then routes every click into the spindle accumulator, and lines 332-343 apply it via SetSpindleSpeed() whenever the spindle is running — no IsSelected() check (compare OverrideCtrlScr, which gates correctly). Brushing the wheel on screen entry while the spindle runs jumps RPM by 100/click. Fix: gate on spindle_dw.IsSelected().

S3. Buffered wheel clicks fire as real motion on screen re-entry. axis_jog_val[], jog_val, axis_jog_dir[] (DirectControlScr) and feed_val/speed_val (OverrideCtrlScr) are never cleared in Show()/Hide(). Clicks landing between the last 20 ms tick and a screen switch stay buffered; when you return to the screen, the first TimerExpired sends a jog for the previously-selected axis with zero wheel input. Fix: zero them in Show().

S4. Rotary table "capture center" button doesn't work. The right-button handler writes only the display widgets (RotaryTableScr.cpp:493-496), but TimerExpired treats the center_x/center_y members as authoritative and reverts the widgets within one tick (RotaryTableScr.cpp:266-271). The operator believes the center is captured; the next arc orbits the stale center (typically 0,0) straight across the work. Fix: set the members in the handler.

S5. Rotary table commits its position model even when the jog is rejected. RotaryTableScr.cpp:292-311 and 314-345 update start_/current_ state before calling JogMultiple/JogArcXYR and ignore the returned Result. A radius change while an arc is still running (RUN state — JogMultiple refuses, JogArcXYR doesn't) desyncs the model; the next arc is computed from a phantom point → grbl error 33/34 or an unintended arc through the work. Fix: commit state only on RESULT_OK.

S6. Encoder stays live during probing sequences. Touch is gated while a sequence runs, but the CenterFinder/EdgeFinder encoder callbacks (ProbeScr.cpp:802, 1533) have no state == PROBE_CNT guard, and the sequence re-reads dw_distance/dw_clearance fresh at each step. A bumped wheel mid-sequence shrinks the return-move target into the workpiece flank (rapid crash at dive depth); in EdgeFinder it also silently rewrites the probe-tip diameter in FRAM. Fix: bail out of both callbacks unless idle.

S7. Scale button can display a step 10× smaller than reality. The trailing-zero trim in ValueToStringWithUnits (GrblComm.cpp:1267) keeps trimming after removing the decimal point: "10.000" → "1". With the max rotary step (10.000 deg/click) the button reads "1 deg" while each click actually moves 10 deg. Fix: stop trimming once the '.' is removed.

Major ### functional bugs
M1. Write-after-free through the interpreter's dangling output buffer (heap corruption). GCodeGeneratorScr.cpp:302 installs ProgramSender's buffer as the Little-C output, then line 329 frees that buffer after prescan — nothing clears LittleC::p_output. Until Generate is pressed, menu Cancel (line 390 → ResetGlobalVariableValue) re-evaluates an initializer; any error (step set to 0 with total/step) or a println() in an initializer writes hundreds of bytes through the freed pointer — over heap_4 free-list metadata. Fix: SetOutputBuf(nullptr, 0) wherever the buffer is released.

M2. Full status report after MPG connect is never actually transmitted (DMA use-after-modify). GrblComm.cpp:139-141 starts HAL_UART_Transmit_DMA from &status_request_command, then the next line overwrites that byte back to '?' before the DMA fetches it. The CMD_STATUS_REPORT_ALL (0x87) set by GainControl() effectively never goes out, so WCO/overrides/pins stay stale after connect until periodic refresh. Fix: transmit from a separate byte that isn't immediately modified.

M3. f_read result ignored — a truncated program is displayed and runnable. ProgramSender.cpp:520-530 (and GCodeGeneratorScr.cpp:291) null-terminate at whatever wbytes a failing read returned and show it as a normal program. Truncation mid-line can turn G1 X100.5 into G1 X10 as the final line — valid, wrong, and runnable. Fix: check fres/wbytes == fsize and show an error.

M4. Settings change while a modal is open cross-wires the value box into a work-offset command. The IsSettingsChanged() re-init (Application.cpp:157-180) force-switches to screen 0 without dismissing msg_box/change_value_box (SettingsScr's Hide() doesn't close it). The still-open box's OK then routes to DirectControlScr, which interprets it as SetAxisPosition(menu_index_as_axis, feed_as_position) → silent work-zero shift. New-screen handlers also register ahead of the modal's (head insertion, first-match dispatch), so the wheel acts underneath the modal. Fix: hide modals in the settings-changed path.

M5. ToolOffset probing hangs on ALARM. ToolOffsetTab::TimerExpired (ProbeScr.cpp:1700) lacks the abort-on-bad-state guard both sibling tabs have (ProbeScr.cpp:436, 1237). A failed G38.2 raises ALARM: (no ok/error:), so the state machine waits forever with screen change disabled; recovery requires guessing "Unlock". Fix: add the same guard.

M6. Run with no/stale program spins forever. ProgramSender enables Run with nothing loaded; worse, after opening a too-big file (SD line mode), stopping mid-stream and leaving the screen (which closes SDFile), returning and pressing Run makes f_gets fail on the closed file with finished never set — empty commands every 20 ms, screen change disabled, until Stop (ProgramSender.cpp:255-304). Fix: gate Run on actual content and an is-open flag.